### PR TITLE
Extension updated for newer versions of slicer

### DIFF
--- a/LookingGlass/Logic/vtkSlicerLookingGlassLogic.cxx
+++ b/LookingGlass/Logic/vtkSlicerLookingGlassLogic.cxx
@@ -227,6 +227,27 @@ void vtkSlicerLookingGlassLogic::SetLookingGlassConnected(bool connect)
     if (this->ActiveViewNode)
       {
       this->ActiveViewNode->SetVisibility(1);
+
+      // Always set the reference view node to the first visible 3D view node
+      vtkMRMLScene* scene = this->GetMRMLScene();
+      if (scene)
+        {
+        vtkSmartPointer<vtkCollection> nodes = vtkSmartPointer<vtkCollection>::Take(
+            scene->GetNodesByClass("vtkMRMLViewNode"));
+        vtkMRMLViewNode* viewNode = nullptr;
+        vtkCollectionSimpleIterator it;
+        for (nodes->InitTraversal(it); (viewNode = vtkMRMLViewNode::SafeDownCast(
+                                          nodes->GetNextItemAsObject(it)));)
+          {
+          if (viewNode->GetVisibility() && viewNode->IsMappedInLayout())
+            {
+            // Found a view node displayed in current layout, use this
+            break;
+            }
+          }
+        // Either use a view node displayed in current layout or just any 3D view node found in the scene
+        this->ActiveViewNode->SetAndObserveReferenceViewNode(viewNode);
+        }
       }
     else
       {


### PR DESCRIPTION
This PR updates the extension to work with the newer versions of Slicer.

1. Fixes problem in build with vtkMRMLLookingGlassViewDisplayableManagerFactory and vtkSingleton.
2. SetCurrentRenderer call removed as it is not available anymore.
3. Fixes Renderer being nullptr when trying to connect to LookingGlass device.
4. When setting up LookingGlass connection makes the reference view the 3D by default.